### PR TITLE
Lighten up regexp to allow other shells than bash

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const PARTICLE_VELOCITY_RANGE = {
 exports.middleware = (store) => (next) => (action) => {
   if ('SESSION_ADD_DATA' === action.type) {
     const { data } = action;
-    if (/bash: wow: command not found/.test(data)) {
+    if ((/wow: command not found/.test(data)) || (/command not found: wow/.test(data))) {
       store.dispatch({
         type: 'WOW_MODE_TOGGLE'
       });
@@ -115,7 +115,7 @@ exports.decorateTerm = (Term, { React, notify }) => {
 
     _spawnParticles (x, y) {
       // const { colors } = this.props;
-      const colors = this.props.wowMode 
+      const colors = this.props.wowMode
         ? this.props.colors
         : [toHex(this.props.cursorColor)];
       const numParticles = PARTICLE_NUM_RANGE();


### PR DESCRIPTION
* Allows the extension to work with shells like zsh and sh as the
  previous regexp was specifically targetting bash.

I found that this solved the problem in many shells. It's definitely possible to create a more powerful regex to handle even more shells in one regex but I figured you might want to see if there's any demand for that before making the code way harder to reader. 