### PR TITLE
bug: correctly pass wow mode to Term

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,11 +42,14 @@ exports.mapTermsState = (state, map) => {
   });
 };
 
-exports.getTermProps = (uid, parentProps, props) => {
+const passProps = (uid, parentProps, props) => {
   return Object.assign(props, {
     wowMode: parentProps.wowMode
   });
 }
+
+exports.getTermGroupProps = passProps;
+exports.getTermProps = passProps;
 
 // code based on
 // https://atom.io/packages/power-mode
@@ -118,7 +121,7 @@ exports.decorateTerm = (Term, { React, notify }) => {
 
     _spawnParticles (x, y) {
       // const { colors } = this.props;
-      const colors = this.props.wowMode 
+      const colors = this.props.wowMode
         ? values(this.props.colors).map(toHex)
         : [toHex(this.props.cursorColor)];
       const numParticles = PARTICLE_NUM_RANGE();


### PR DESCRIPTION
Since we added a component between Terms and Term, the `wowMode` prop wasn't correctly passed anymore. Probably fixes #23?