### PR TITLE
Fix broken powershell detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function detectWowCommand(data) {
     'wow: command not found',
     'command not found: wow',
     'Unknown command \'wow\'',
-    '\'wow\' is not recognized.*'
+    '\'wow\' is not recognized*'
   ];
   return new RegExp('(' + patterns.join(')|(') + ')').test(data)
 }


### PR DESCRIPTION
The error message is " The term 'wow' is not recognized as [...]", which the period breaks. This should solve that issue.