### PR TITLE
check for term reference before accessing properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ exports.decorateTerm = (Term, { React, notify }) => {
 
     _onDecorated (term) {
       if (this.props.onDecorated) this.props.onDecorated(term);
-      this._div = term.termRef;
+      this._div = term ? term.termRef : null;
       this._initCanvas();
     }
 


### PR DESCRIPTION
When closing tabs, the 'term' parameter to _onDecorated is null. This PR simply checks for a valid term reference before accessing properties.